### PR TITLE
Правильно отпределяем размеры картинки даже если файл уже читали.

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -145,6 +145,8 @@ module Paperclip
     end
 
     def valid_image_resolution? file
+      # FastImage don`t rewind file if it readed before.
+      file.rewind if file.respond_to?(:rewind)
       sizes = FastImage.size(file)
       !sizes || (sizes[0] <= MAX_IMAGE_RESOLUTION && sizes[1] <= MAX_IMAGE_RESOLUTION)
     end

--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -145,9 +145,7 @@ module Paperclip
     end
 
     def valid_image_resolution? file
-      # FastImage don`t rewind file if it readed before.
-      file.rewind if file.respond_to?(:rewind)
-      sizes = FastImage.size(file)
+      sizes = FastImage.size(file.path)
       !sizes || (sizes[0] <= MAX_IMAGE_RESOLUTION && sizes[1] <= MAX_IMAGE_RESOLUTION)
     end
 


### PR DESCRIPTION
FastImage не делает rewind для файла и если ей подсунуть уже прочитанный
файл возвращает nil.

![image](https://user-images.githubusercontent.com/7142331/49203241-8a9ee000-f3b8-11e8-9d93-edf6628ae277.png)
