### PR TITLE
Create separate class for every attachment definition

### DIFF
--- a/lib/paperclip.rb
+++ b/lib/paperclip.rb
@@ -216,7 +216,8 @@ module Paperclip
       include InstanceMethods
 
       self.attachment_definitions = self.attachment_definitions&.dup || {}
-      attachment_definitions[name] = {:validations => []}.merge(options)
+      attachment_definitions[name] = Attachment.build_class(name, options)
+      const_set("#{name}_attachment".camelize, attachment_definitions[name])
 
       after_save :save_attached_files
       after_commit :destroy_attached_files, on: :destroy
@@ -291,7 +292,7 @@ module Paperclip
     end
 
     def _add_attachment_validation(name, type, default_options, options)
-      attachment_definitions[name][:validations] << [
+      attachment_definitions[name].validations << [
         type,
         **options,
         **default_options.slice(:message, :if, :unless)
@@ -302,7 +303,7 @@ module Paperclip
   module InstanceMethods #:nodoc:
     def attachment_for name
       @_paperclip_attachments ||= {}
-      @_paperclip_attachments[name] ||= Attachment.build(name, self, self.class.attachment_definitions[name])
+      @_paperclip_attachments[name] ||= self.class.attachment_definitions[name].new(self)
     end
 
     def each_attachment

--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -256,6 +256,14 @@ module Paperclip
       instance_read(:content_type)
     end
 
+    def to_file(style = default_style)
+      queued_for_write[style]
+    end
+
+    def to_io(*args)
+      to_file(*args)
+    end
+
     # Returns the last modified time of the file as originally assigned, and
     # lives in the <attachment>_updated_at attribute of the model.
     def updated_at

--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -43,7 +43,8 @@ module Paperclip
       attr_reader :attachment_name, :options, :validations
 
       # Extracted from options
-      attr_reader :url_template, :path_template, :default_url, :processing_url, :styles, :default_style, :whiny
+      attr_reader :url_template, :path_template, :default_url, :processing_url,
+        :styles, :all_styles, :default_style, :whiny
 
       def setup(name, options)
         @attachment_name  = name
@@ -54,6 +55,7 @@ module Paperclip
         @default_url      = options[:default_url]
         @processing_url   = options[:processing_url] || default_url
         @styles           = StylesParser.new(options).styles
+        @all_styles       = [:original, *styles.keys].uniq
         @default_style    = options[:default_style]
         @whiny            = options[:whiny_thumbnails] || options[:whiny]
       end
@@ -412,8 +414,7 @@ module Paperclip
 
     def queue_existing_for_delete #:nodoc:
       return unless file?
-      all_styles = [:original, *styles.keys]
-      queued_for_delete.concat(all_styles.uniq.map { |style| filesystem_path(style) }.compact)
+      queued_for_delete.concat(self.class.all_styles)
     end
 
     def flush_errors #:nodoc:

--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -166,17 +166,13 @@ module Paperclip
     def url style = default_style, include_updated_timestamp = true
       # for delayed_paperclip
       return interpolate(self.class.processing_url, style) if instance.try("#{name}_processing?")
-      interpolate_url(self.class.url_template, style, include_updated_timestamp)
+      url = original_filename.nil? ? interpolate(self.class.default_url, style) : storage_url(style)
+      return url unless include_updated_timestamp && (time_param = updated_at)
+      "#{url}#{url.include?("?") ? "&" : "?"}#{time_param}"
     end
 
-    # Метод необходим в ассетах
-    def filesystem_url style = default_style, include_updated_timestamp = true
-      interpolate_url(self.class.url_template, style, include_updated_timestamp)
-    end
-
-    def interpolate_url(template, style, include_updated_timestamp)
-      url = original_filename.nil? ? interpolate(self.class.default_url, style) : interpolate(template, style)
-      include_updated_timestamp && updated_at ? [url, updated_at].compact.join(url.include?("?") ? "&" : "?") : url
+    def storage_url(style = default_style)
+      interpolate(self.class.url_template, style)
     end
 
     # Returns the path of the attachment as defined by the :path option. If the
@@ -187,8 +183,6 @@ module Paperclip
       return if original_filename.nil?
       interpolate(self.class.path_template, style)
     end
-
-    alias_method :filesystem_path, :path
 
     # Alias to +url+
     def to_s style = nil

--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -1,6 +1,8 @@
 require 'fastimage'
 
 require 'paperclip/styles_parser'
+require 'active_support/core_ext/module/delegation'
+require 'active_support/core_ext/string/inflections'
 
 module Paperclip
   # The Attachment class manages the files for a given attachment. It saves

--- a/lib/paperclip/callback_compatability.rb
+++ b/lib/paperclip/callback_compatability.rb
@@ -1,3 +1,5 @@
+require 'active_support/version'
+
 module Paperclip
   module CallbackCompatability
     module_function
@@ -33,7 +35,7 @@ module Paperclip
     module Rails3
       module Defining
         TERMINATOR =
-          if Gem::Version.new(ActiveRecord::VERSION::STRING) >= Gem::Version.new('4.1')
+          if Gem::Version.new(ActiveSupport::VERSION::STRING) >= Gem::Version.new('4.1')
             ->(target, result) { result == false }
           else
             'result == false'

--- a/lib/paperclip/interpolations.rb
+++ b/lib/paperclip/interpolations.rb
@@ -47,7 +47,7 @@ module Paperclip
     # So it just interpolates :url template without checking if preocessing and
     # file existence.
     def url attachment, style_name
-      interpolate(attachment.options[:url], attachment, style_name)
+      interpolate(attachment.class.url_template, attachment, style_name)
     end
 
     # Returns the timestamp as defined by the <attachment>_updated_at field

--- a/lib/paperclip/storage/delayeds3.rb
+++ b/lib/paperclip/storage/delayeds3.rb
@@ -141,7 +141,7 @@ module Paperclip
       end
 
       def to_file style = default_style
-        queued_for_write[style] || (File.new(filesystem_path(style), 'rb') if exists?(style)) || download_file(style)
+        super || (File.new(filesystem_path(style), 'rb') if exists?(style)) || download_file(style)
       end
 
       def download_file(style = default_style)
@@ -150,8 +150,6 @@ module Paperclip
         response = Net::HTTP.get_response(uri)
         create_tempfile(response.body) if response.is_a?(Net::HTTPOK)
       end
-
-      alias_method :to_io, :to_file
 
       def exists?(style = default_style)
         File.exist?(filesystem_path(style))

--- a/lib/paperclip/storage/delayeds3.rb
+++ b/lib/paperclip/storage/delayeds3.rb
@@ -163,7 +163,7 @@ module Paperclip
 
       def filesystem_paths
         h = {}
-        [:original, *styles.keys].uniq.map do |style|
+        self.class.all_styles.uniq.map do |style|
           path = filesystem_path(style)
           h[style] = path if File.exist?(path)
         end
@@ -271,7 +271,8 @@ module Paperclip
           return
         end
 
-        queued_for_delete.each do |path|
+        queued_for_delete.each do |style|
+          path = filesystem_path(style)
           log("Deleting local file #{path}")
           delete_recursive(path)
         end

--- a/lib/paperclip/storage/delayeds3.rb
+++ b/lib/paperclip/storage/delayeds3.rb
@@ -119,16 +119,9 @@ module Paperclip
         @queued_jobs = []
       end
 
-      def url(style = default_style, include_updated_timestamp = true)
-        # for delayed_paperclip
-        return interpolate(self.class.processing_url, style) if instance.try("#{name}_processing?")
+      def storage_url(style = default_style)
         template = instance_read(:synced_to_s3) ? self.class.s3_url_template : self.class.filesystem_url_template
-        interpolate_url(template, style, include_updated_timestamp)
-      end
-
-      # Метод необходим в ассетах
-      def filesystem_url(style = default_style, include_updated_timestamp = true)
-        interpolate_url(self.class.filesystem_url_template, style, include_updated_timestamp)
+        interpolate(template, style)
       end
 
       def path(style = default_style)

--- a/lib/paperclip/storage/filesystem.rb
+++ b/lib/paperclip/storage/filesystem.rb
@@ -27,9 +27,8 @@ module Paperclip
       # Returns representation of the data of the file assigned to the given
       # style, in the format most representative of the current storage.
       def to_file style = default_style
-        queued_for_write[style] || (File.new(path(style), 'rb') if exists?(style))
+        super || (File.new(path(style), 'rb') if exists?(style))
       end
-      alias_method :to_io, :to_file
 
       def flush_writes #:nodoc:
         queued_for_write.each do |style, file|

--- a/lib/paperclip/storage/filesystem.rb
+++ b/lib/paperclip/storage/filesystem.rb
@@ -27,12 +27,12 @@ module Paperclip
       # Returns representation of the data of the file assigned to the given
       # style, in the format most representative of the current storage.
       def to_file style = default_style
-        @queued_for_write[style] || (File.new(path(style), 'rb') if exists?(style))
+        queued_for_write[style] || (File.new(path(style), 'rb') if exists?(style))
       end
       alias_method :to_io, :to_file
 
       def flush_writes #:nodoc:
-        @queued_for_write.each do |style, file|
+        queued_for_write.each do |style, file|
           file.close
           filename = path(style)
           FileUtils.mkdir_p(File.dirname(filename))
@@ -40,11 +40,11 @@ module Paperclip
           FileUtils.mv(file.path, filename)
           FileUtils.chmod(0644, filename)
         end
-        @queued_for_write = {}
+        queued_for_write.clear
       end
 
       def flush_deletes #:nodoc:
-        @queued_for_delete.each do |path|
+        queued_for_delete.each do |path|
           begin
             log("deleting #{path}")
             FileUtils.rm(path)
@@ -67,7 +67,7 @@ module Paperclip
             # Ignore it
           end
         end
-        @queued_for_delete = []
+        queued_for_delete.clear
       end
     end
   end

--- a/lib/paperclip/storage/filesystem.rb
+++ b/lib/paperclip/storage/filesystem.rb
@@ -44,7 +44,8 @@ module Paperclip
       end
 
       def flush_deletes #:nodoc:
-        queued_for_delete.each do |path|
+        queued_for_delete.each do |style|
+          path = self.path(style)
           begin
             log("deleting #{path}")
             FileUtils.rm(path)

--- a/test/interpolations_test.rb
+++ b/test/interpolations_test.rb
@@ -67,7 +67,7 @@ class InterpolationsTest < Test::Unit::TestCase
   end
 
   should "reinterpolate :url" do
-    attachment = stub(options: {url: "/:id/"}, instance: stub(id: "1234"))
+    attachment = stub(class: stub(url_template: "/:id/"), instance: stub(id: "1234"))
     assert_equal "/1234/", Paperclip::Interpolations.url(attachment, :style)
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -83,5 +83,5 @@ class FakeModel
 end
 
 def attachment options
-  Paperclip::Attachment.new(:avatar, FakeModel.new, options)
+  Paperclip::Attachment.build_class(:avatar, options).new(FakeModel.new)
 end


### PR DESCRIPTION
This way all settings are stored at class-level, it makes it easier to understand which options are instance-dependent and which are common.