### PR TITLE
Fix deleting old files when attachment is updated

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -425,7 +425,13 @@ module Paperclip
 
     def queue_existing_for_delete #:nodoc:
       return unless file?
-      queued_for_delete.concat(self.class.all_styles)
+      action = delete_styles_later(self.class.all_styles)
+      queued_for_delete << action if action
+    end
+
+    def flush_deletes
+      queued_for_delete.each(&:call)
+      queued_for_delete.clear
     end
 
     def flush_errors #:nodoc:

--- a/lib/paperclip/storage/filesystem.rb
+++ b/lib/paperclip/storage/filesystem.rb
@@ -42,9 +42,13 @@ module Paperclip
         queued_for_write.clear
       end
 
-      def flush_deletes #:nodoc:
-        queued_for_delete.each do |style|
-          path = self.path(style)
+      def delete_styles_later(styles)
+        filenames = styles.map { |style| path(style) }
+        -> { delete_files(filenames) }
+      end
+
+      def delete_files(filenames)
+        filenames.each do |path|
           begin
             log("deleting #{path}")
             FileUtils.rm(path)
@@ -67,7 +71,6 @@ module Paperclip
             # Ignore it
           end
         end
-        queued_for_delete.clear
       end
     end
   end


### PR DESCRIPTION
Before the fix identifiers for deletion were calculated
after file_name was updated. Now each storage stores original identifiers
in delete_styles_later and removes them when flush_writes called.