### PR TITLE
При загрузке в облака определяем content-type для каждого файла независимо

### DIFF
--- a/lib/paperclip/optimizer.rb
+++ b/lib/paperclip/optimizer.rb
@@ -12,8 +12,7 @@ module Paperclip
     end
 
     def real_content_type
-      out = Paperclip.run "file", "--mime-type #{@file.path.shellescape}"
-      out.split(/:\s+/)[1].gsub("\n", "")
+      Paperclip::Upfile.content_type_from_file(@file.path)
     end
 
     def optimize(file)

--- a/lib/paperclip/storage/delayeds3.rb
+++ b/lib/paperclip/storage/delayeds3.rb
@@ -184,6 +184,10 @@ module Paperclip
         h
       end
 
+      def file_content_type(path)
+        Paperclip::Upfile.content_type_from_file path
+      end
+
       def write_to_s3
         return true if instance_read(:synced_to_s3)
         paths = filesystem_paths
@@ -195,7 +199,7 @@ module Paperclip
             s3_object = self.class.aws_bucket.object(s3_path(style))
             s3_object.upload_file(file,
                                   cache_control: "max-age=#{10.year.to_i}",
-                                  content_type: instance_read(:content_type),
+                                  content_type: file_content_type(file),
                                   expires: 10.year.from_now.httpdate,
                                   acl: 'public-read')
         end
@@ -215,7 +219,7 @@ module Paperclip
             s3_object = self.class.yandex_bucket.object(s3_path(style))
             s3_object.upload_file(file,
                                   cache_control: "max-age=#{10.year.to_i}",
-                                  content_type: instance_read(:content_type),
+                                  content_type: file_content_type(file),
                                   expires: 10.year.from_now.httpdate,
                                   acl: 'public-read')
         end
@@ -235,7 +239,7 @@ module Paperclip
             s3_object = self.class.sbercloud_bucket.object(s3_path(style))
             s3_object.upload_file(file,
                                   cache_control: "max-age=#{10.year.to_i}",
-                                  content_type: instance_read(:content_type),
+                                  content_type: file_content_type(file),
                                   expires: 10.year.from_now.httpdate,
                                   acl: 'public-read')
         end
@@ -255,7 +259,7 @@ module Paperclip
           path = s3_path(style)
           log "Saving to Fog with key #{path}"
           options = {
-            "Content-Type" => instance_read(:content_type),
+            "Content-Type" => file_content_type(file),
             "Cache-Control" => "max-age=#{10.year.to_i}",
             "x-goog-acl" => "public-read"
           }

--- a/lib/paperclip/upfile.rb
+++ b/lib/paperclip/upfile.rb
@@ -5,10 +5,11 @@ module Paperclip
   module Upfile
     # Infer the MIME-type of the file from the extension.
     def content_type
-      Paperclip::Upfile.content_type self.path
+      Paperclip::Upfile.content_type_from_ext self.path
     end
 
-    def self.content_type path
+    # TODO: Переписать через MIME::Types
+    def self.content_type_from_ext(path)
       type = (path.match(/\.(\w+)$/)[1] rescue "octet-stream").downcase
       case type
       when %r"jpe?g"                 then "image/jpeg"
@@ -20,6 +21,13 @@ module Paperclip
       when "liquid"                  then "text/x-liquid"
       else "application/x-#{type}"
       end
+    end
+
+    def self.content_type_from_file(path)
+      Paperclip
+        .run("file", "--mime-type #{path.shellescape}")
+        .split(/:\s+/)[1]
+        .gsub("\n", "")
     end
 
     attr_writer :original_filename
@@ -45,7 +53,7 @@ if defined? StringIO
     end
 
     def content_type
-      @content_type ||= Paperclip::Upfile.content_type original_filename
+      @content_type ||= Paperclip::Upfile.content_type_from_ext original_filename
     end
   end
 end


### PR DESCRIPTION
https://insales.atlassian.net/browse/D2C-661

Оригинальный файл и пережатые могут иметь разные форматы. Даже разные
стили могут иметь разные форматы. Передавать для всех content-type
оригинального файла неправильно.