### PR TITLE
Запускаем системные команды с таймаутом 30с

### DIFF
--- a/lib/paperclip.rb
+++ b/lib/paperclip.rb
@@ -107,7 +107,7 @@ module Paperclip
       command = %Q<#{%Q[#{path_for_command(cmd)} #{params}].gsub(/\s+/, " ")}>
       command = "#{command} 2>#{bit_bucket}" if Paperclip.options[:swallow_stderr]
       Paperclip.log(command) if Paperclip.options[:log_command]
-      output = `#{command}`
+      output = `timeout 30 #{command}`
       unless [expected_outcodes].flatten.include?($?.exitstatus)
         raise PaperclipCommandLineError, "Error while running #{cmd}"
       end


### PR DESCRIPTION
Иногда команда может зависать. Например, convert и identify на некоторых
svg файлах