### PR TITLE
Правильно определяем тип картинок webp по расширению

### DIFF
--- a/lib/paperclip/upfile.rb
+++ b/lib/paperclip/upfile.rb
@@ -15,6 +15,7 @@ module Paperclip
       when %r"jpe?g"                 then "image/jpeg"
       when %r"tiff?"                 then "image/tiff"
       when %r"png", "gif", "bmp"     then "image/#{type}"
+      when "webp"                    then "image/webp"
       when "txt"                     then "text/plain"
       when %r"html?"                 then "text/html"
       when "csv", "xml", "css", "js" then "text/#{type}"


### PR DESCRIPTION
<img width="612" alt="image" src="https://user-images.githubusercontent.com/7142331/155096827-9a4d7f68-2617-46cb-ab4a-f34c59b6ddf0.png">

Сейчас webp определяется как `application/x-webp`