### PR TITLE
Прибиваем версию руби, чтобы не было неожиданных

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ jobs:
           - ruby-version: 2.7.5
             rails-version: 70
           # EDGE
-          - ruby-version: 3.1
+          - ruby-version: 3.1.0
             rails-version: 70
 
     env:


### PR DESCRIPTION
 падений при выходе новой версии