### PR TITLE
Скачиваем файл из S3, используя библиотеку, а не по ссылке

### DIFF
--- a/lib/paperclip/storage/no_cache_s3.rb
+++ b/lib/paperclip/storage/no_cache_s3.rb
@@ -93,10 +93,7 @@ module Paperclip
         return unless synced_to?(self.class.main_store_id)
 
         if self.class.download_by_url
-          # FIXME: do we need to escape here?
-          uri = URI(URI::DEFAULT_PARSER.escape(storage_url(style)))
-          response = Net::HTTP.get_response(uri)
-          create_tempfile(response.body) if response.is_a?(Net::HTTPOK)
+          create_tempfile(self.class.main_store_id.object(style_key).get.body.read)
         else
           download_from_store(self.class.main_store_id, style_key)
         end


### PR DESCRIPTION
Потому что:
 а) Зачем изобретать велосипед?
 б) Ссылка -- публичная. Для файлов, загруженных в приватном режиме, она не сработает.