### PR TITLE
Заменяем Addressable::URI#normalize на сочетание normalized_host и escape

### DIFF
--- a/lib/paperclip/storage/no_cache_s3.rb
+++ b/lib/paperclip/storage/no_cache_s3.rb
@@ -187,14 +187,16 @@ module Paperclip
       # К ссылке, сформированной по паттерну (например, через наш CDN), добавляем параметры с подписью
       def presigned_url(style)
         uri = Addressable::URI.parse(storage_url(style))
+        uri.host = uri.normalized_host # punycode домена
         basic_params = uri.query_values || {}
         presign_params = Addressable::URI.parse(
           self.class.store_by(self.class.main_store_id).object(key(style)).presigned_url(:get)
         ).query_values
 
         result_params = basic_params.merge(presign_params)
-        uri.query_values = result_params
-        uri.normalize.to_s
+        uri.query_values = result_params # тут addressable сам заэскейпит параметры
+        uri.path = Addressable::URI.escape(uri.path)
+        uri.to_s
       end
 
       def synced_to?(store_id)


### PR DESCRIPTION
Обычный `normalize` слишком строго заменяет некоторые символы типа странного Й