### PR TITLE
Переименовываем временные файлы, чтобы проверить, кто их создаёт

### DIFF
--- a/lib/paperclip/iostream.rb
+++ b/lib/paperclip/iostream.rb
@@ -5,7 +5,7 @@ module IOStream
   def to_tempfile(object)
     return object.to_tempfile if object.respond_to?(:to_tempfile)
     name = object.respond_to?(:original_filename) ? object.original_filename : (object.respond_to?(:path) ? object.path : "stream")
-    tempfile = Tempfile.new(["stream", File.extname(name)])
+    tempfile = Tempfile.new(["ppc-iostream", File.extname(name)])
     tempfile.binmode
     stream_to(object, tempfile)
   end


### PR DESCRIPTION
На проде создаётся очень много временных файлов со `stream` в имени. Они не удаляются и занимают место.
Переименовываем их, чтобы было проще найти виновного.