### PR TITLE
Делаем rewind файлам перед чтением

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -276,7 +276,9 @@ module Paperclip
     end
 
     def to_file(style = default_style)
-      queued_for_write[style]
+      file = queued_for_write[style]
+      file&.rewind
+      file
     end
 
     def to_io(*args)

--- a/lib/paperclip/storage/no_cache_s3.rb
+++ b/lib/paperclip/storage/no_cache_s3.rb
@@ -234,6 +234,7 @@ module Paperclip
         }.merge(self.class.upload_options)
         files.each do |style, file|
           path = key(style)
+          file.rewind
           log "Saving to #{store_id}:#{path}"
           store.put_object(common_options.merge(key: path, body: file))
         end


### PR DESCRIPTION
Иначе иногда может нарваться на то, что в облако пишется пустая строка