### PR TITLE
Загружаем файлы в after_commit, а не в after_save

### DIFF
--- a/lib/paperclip.rb
+++ b/lib/paperclip.rb
@@ -220,7 +220,7 @@ module Paperclip
       attachment_definitions[name] = Attachment.build_class(name, options)
       const_set("#{name}_attachment".camelize, attachment_definitions[name])
 
-      after_save :save_attached_files
+      after_commit :save_attached_files
       after_commit :destroy_attached_files, on: :destroy
       after_commit :flush_attachment_jobs
 

--- a/lib/paperclip.rb
+++ b/lib/paperclip.rb
@@ -315,8 +315,11 @@ module Paperclip
 
     def save_attached_files
       logger.info("[paperclip] Saving attachments.")
-      each_attachment do |_name, attachment|
+      each_attachment do |name, attachment|
         attachment.send(:save)
+        # переехало сюда из delayed_paperclip process_in_background. нужно чтобы порядок загрузки - обработки
+        # не поломало
+        enqueue_delayed_processing if attachment_definitions[name][:delayed].present?
       end
     end
 

--- a/lib/paperclip/storage/no_cache_s3.rb
+++ b/lib/paperclip/storage/no_cache_s3.rb
@@ -183,7 +183,7 @@ module Paperclip
         # ignore deleted objects and skip callbacks
         return if instance.class.unscoped.where(id: instance.id).update_all(synced_field_name => true) != 1
 
-        instance.touch
+        instance.updated_at = Time.current if instance.respond_to?(:updated_at=)
         instance[synced_field_name] = true
       end
 

--- a/test/storage/cached_test.rb
+++ b/test/storage/cached_test.rb
@@ -70,6 +70,7 @@ class CachedStorageTest < Test::Unit::TestCase
 
       should 'write to permanent stores and clear cache' do
         @instance.update!(avatar: stub_file('test.txt', 'qwe'))
+        @instance.run_callbacks(:commit)
         @instance.reload
         attachment = @instance.avatar
         key = attachment.key

--- a/test/storage/no_cache_s3_test.rb
+++ b/test/storage/no_cache_s3_test.rb
@@ -61,6 +61,7 @@ class NoCacheS3Test < Test::Unit::TestCase
       @store1_stub.expects(:put_object).once
       @store2_stub.expects(:put_object).never
       @instance.update!(avatar: stub_file('test.txt', 'qwe'))
+      @instance.run_callbacks(:commit)
       @instance.reload
       attachment = @instance.avatar
       assert_equal 'http://store.local/test.txt', attachment.url(:original, false)
@@ -74,6 +75,7 @@ class NoCacheS3Test < Test::Unit::TestCase
         @store1_stub.expects(:put_object).once
         @store2_stub.expects(:put_object).once
         @instance.update!(avatar: stub_file('test.txt', 'qwe'))
+        @instance.run_callbacks(:commit)
         @instance.reload
         attachment = @instance.avatar
         assert_equal 'http://store.local/test.txt', attachment.url(:original, false)


### PR DESCRIPTION
Иначе мы грузим файлы внутри транзакции.
Это и так плохо, но еще и может киляться по таймауту тарнзакции, если файл большой.

https://github.com/insales/delayed_paperclip/pull/3