### PR TITLE
ruby 3.3 support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,9 @@ jobs:
         include:
           - ruby-version: 3.2.3
             rails-version: 70
-          - ruby-version: 3.2.3
+          - ruby-version: 3.3.1
+            rails-version: 70
+          - ruby-version: 3.3.1
             rails-version: 71
 
     env:

--- a/lib/paperclip/iostream.rb
+++ b/lib/paperclip/iostream.rb
@@ -1,10 +1,18 @@
+# frozen_string_literal: true
+
 # Provides method that can be included on File-type objects (IO, StringIO, Tempfile, etc) to allow stream copying
 # and Tempfile conversion.
 module IOStream
   # Returns a Tempfile containing the contents of the readable object.
   def to_tempfile(object)
     return object.to_tempfile if object.respond_to?(:to_tempfile)
-    name = object.respond_to?(:original_filename) ? object.original_filename : (object.respond_to?(:path) ? object.path : "stream")
+    name = if object.respond_to?(:original_filename)
+             object.original_filename
+           elsif object.respond_to?(:path)
+             object.path
+           else
+             "stream"
+           end
     tempfile = Tempfile.new(["ppc-iostream", File.extname(name)])
     tempfile.binmode
     stream_to(object, tempfile)
@@ -13,32 +21,15 @@ module IOStream
   # Copies one read-able object from one place to another in blocks, obviating the need to load
   # the whole thing into memory. Defaults to 8k blocks. Returns a File if a String is passed
   # in as the destination and returns the IO or Tempfile as passed in if one is sent as the destination.
-  def stream_to object, path_or_file, in_blocks_of = 8192
+  def stream_to(object, path_or_file, in_blocks_of = 8192)
     dstio = case path_or_file
             when String then File.new(path_or_file, "wb+")
             when IO, Tempfile then path_or_file
             end
-    buffer = ""
+    buffer = +""
     object.rewind
-    while object.read(in_blocks_of, buffer) do
-      dstio.write(buffer)
-    end
+    dstio.write(buffer) while object.read(in_blocks_of, buffer)
     dstio.rewind
     dstio
-  end
-end
-
-# Corrects a bug in Windows when asking for Tempfile size.
-if defined?(Tempfile) && RUBY_PLATFORM !~ /java/
-  class Tempfile
-    def size
-      if @tmpfile
-        @tmpfile.fsync
-        @tmpfile.flush
-        @tmpfile.stat.size
-      else
-        0
-      end
-    end
   end
 end


### PR DESCRIPTION
- **Test on ruby 3.3**
- **Tempfile#size patch was broken on ruby 3.3, also fix rubocop**
