### PR TITLE
[CS-9964] если подключен кастомный CDN, то в процессе метода to_file мы пытаемся обращаться к этому cdn, а он сейчас работает нестабильно и отдает 404

### DIFF
--- a/lib/paperclip.rb
+++ b/lib/paperclip.rb
@@ -108,6 +108,7 @@ module Paperclip
       command = %Q<#{%Q[#{path_for_command(cmd)} #{params}].gsub(/\s+/, " ")}>
       command = "#{command} 2>#{bit_bucket}" if Paperclip.options[:swallow_stderr]
       Paperclip.log(command) if Paperclip.options[:log_command]
+      binding.pry
       output = `timeout #{cmd == "convert" ? 60 : 30} #{command}`
       unless [expected_outcodes].flatten.include?($?.exitstatus)
         raise PaperclipCommandLineError, "Error while running #{cmd}"

--- a/lib/paperclip.rb
+++ b/lib/paperclip.rb
@@ -108,7 +108,6 @@ module Paperclip
       command = %Q<#{%Q[#{path_for_command(cmd)} #{params}].gsub(/\s+/, " ")}>
       command = "#{command} 2>#{bit_bucket}" if Paperclip.options[:swallow_stderr]
       Paperclip.log(command) if Paperclip.options[:log_command]
-      binding.pry
       output = `timeout #{cmd == "convert" ? 60 : 30} #{command}`
       unless [expected_outcodes].flatten.include?($?.exitstatus)
         raise PaperclipCommandLineError, "Error while running #{cmd}"

--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -501,7 +501,8 @@ module Paperclip
     end
 
     def subject_to_post_process?
-      content_type.include?('image') && content_type.exclude?('svg') && content_type.exclude?('vnd.')
+      type = content_type.to_s
+      type.include?('image') && !type.include?('svg') && !type.include?('vnd.')
     end
   end
 end

--- a/lib/paperclip/storage/no_cache_s3.rb
+++ b/lib/paperclip/storage/no_cache_s3.rb
@@ -191,19 +191,11 @@ module Paperclip
 
       private
 
-      # К ссылке, сформированной по паттерну (например, через наш CDN), добавляем параметры с подписью
-      def presigned_url(style)
-        uri = Addressable::URI.parse(storage_url(style))
-        uri.host = uri.normalized_host # punycode домена
-        basic_params = uri.query_values || {}
-        presign_params = Addressable::URI.parse(
-          self.class.store_by(self.class.main_store_id).object(key(style)).presigned_url(:get)
-        ).query_values
-
-        result_params = basic_params.merge(presign_params)
-        uri.query_values = result_params # тут addressable сам заэскейпит параметры
-        uri.path = Addressable::URI.escape(uri.path)
-        uri.to_s
+      # Прямой S3/bucket URL для внутреннего скачивания (reprocess).
+      # Нельзя брать storage_url (CDN аккаунта): подпись AWS считается под host бакета
+      # (X-Amz-SignedHeaders=host), а кастомный CDN часто отдаёт 404.
+      def download_url(style)
+        self.class.store_by(self.class.main_store_id).object(key(style)).presigned_url(:get)
       end
 
       def synced_to?(store_id)

--- a/lib/paperclip/storage/no_cache_s3.rb
+++ b/lib/paperclip/storage/no_cache_s3.rb
@@ -101,13 +101,8 @@ module Paperclip
         return unless synced_to?(self.class.main_store_id)
 
         if self.class.download_by_url
-          begin
-            URI.parse(unpresigned_url(style)).open do |tempfile|
-              create_tempfile(tempfile.read)
-            end
-          rescue OpenURI::HTTPError, SocketError, Errno::ECONNREFUSED, Net::OpenTimeout, Net::ReadTimeout => e
-            Paperclip.log("download_by_url failed (#{e.class}: #{e.message}), fallback to API")
-            download_from_store(self.class.main_store_id, style_key)
+          URI.parse(url_without_cdn(style)).open do |tempfile|
+            create_tempfile(tempfile.read)
           end
         else
           download_from_store(self.class.main_store_id, style_key)
@@ -209,7 +204,7 @@ module Paperclip
       # Прямой S3/bucket URL для внутреннего скачивания (reprocess).
       # Нельзя брать storage_url (CDN аккаунта): подпись AWS считается под host бакета
       # (X-Amz-SignedHeaders=host), а кастомный CDN на данный момент отдаёт 404.
-      def unpresigned_url(style)
+      def url_without_cdn(style)
         self.class.store_by(self.class.main_store_id).object(key(style)).presigned_url(:get)
       end
 

--- a/lib/paperclip/storage/no_cache_s3.rb
+++ b/lib/paperclip/storage/no_cache_s3.rb
@@ -41,7 +41,9 @@ module Paperclip
           end
           @store_ids = options[:stores].keys.map(&:to_sym)
           @main_store_id = store_ids.first
-          @url_template = options.fetch(:url).gsub(':key', key_template).gsub(':bucket_url', store_by(main_store_id).url)
+          @url_template = options.fetch(:url)
+            .gsub(':key', key_template)
+            .gsub(':bucket_url', store_by(main_store_id).url)
           @download_by_url = options[:download_by_url]
           @upload_options = options[:upload_options] || {}
         end

--- a/lib/paperclip/storage/no_cache_s3.rb
+++ b/lib/paperclip/storage/no_cache_s3.rb
@@ -102,12 +102,11 @@ module Paperclip
 
         if self.class.download_by_url
           begin
-            URI.parse(download_url(style)).open do |tempfile|
+            URI.parse(unpresigned_url(style)).open do |tempfile|
               create_tempfile(tempfile.read)
             end
           rescue OpenURI::HTTPError, SocketError, Errno::ECONNREFUSED, Net::OpenTimeout, Net::ReadTimeout => e
             Paperclip.log("download_by_url failed (#{e.class}: #{e.message}), fallback to API")
-            binding.pry
             download_from_store(self.class.main_store_id, style_key)
           end
         else
@@ -210,7 +209,7 @@ module Paperclip
       # Прямой S3/bucket URL для внутреннего скачивания (reprocess).
       # Нельзя брать storage_url (CDN аккаунта): подпись AWS считается под host бакета
       # (X-Amz-SignedHeaders=host), а кастомный CDN на данный момент отдаёт 404.
-      def download_url(style)
+      def unpresigned_url(style)
         self.class.store_by(self.class.main_store_id).object(key(style)).presigned_url(:get)
       end
 

--- a/lib/paperclip/storage/no_cache_s3.rb
+++ b/lib/paperclip/storage/no_cache_s3.rb
@@ -41,9 +41,7 @@ module Paperclip
           end
           @store_ids = options[:stores].keys.map(&:to_sym)
           @main_store_id = store_ids.first
-          @url_template = options.fetch(:url)
-            .gsub(':key', key_template)
-            .gsub(':bucket_url', store_by(main_store_id).url)
+          @url_template = options.fetch(:url).gsub(':key', key_template).gsub(':bucket_url', store_by(main_store_id).url)
           @download_by_url = options[:download_by_url]
           @upload_options = options[:upload_options] || {}
         end
@@ -107,6 +105,7 @@ module Paperclip
             end
           rescue OpenURI::HTTPError, SocketError, Errno::ECONNREFUSED, Net::OpenTimeout, Net::ReadTimeout => e
             Paperclip.log("download_by_url failed (#{e.class}: #{e.message}), fallback to API")
+            binding.pry
             download_from_store(self.class.main_store_id, style_key)
           end
         else
@@ -191,9 +190,24 @@ module Paperclip
 
       private
 
+      # К ссылке, сформированной по паттерну (например, через наш CDN), добавляем параметры с подписью
+      def presigned_url(style)
+        uri = Addressable::URI.parse(storage_url(style))
+        uri.host = uri.normalized_host # punycode домена
+        basic_params = uri.query_values || {}
+        presign_params = Addressable::URI.parse(
+          self.class.store_by(self.class.main_store_id).object(key(style)).presigned_url(:get)
+        ).query_values
+
+        result_params = basic_params.merge(presign_params)
+        uri.query_values = result_params # тут addressable сам заэскейпит параметры
+        uri.path = Addressable::URI.escape(uri.path)
+        uri.to_s
+      end
+
       # Прямой S3/bucket URL для внутреннего скачивания (reprocess).
       # Нельзя брать storage_url (CDN аккаунта): подпись AWS считается под host бакета
-      # (X-Amz-SignedHeaders=host), а кастомный CDN часто отдаёт 404.
+      # (X-Amz-SignedHeaders=host), а кастомный CDN на данный момент отдаёт 404.
       def download_url(style)
         self.class.store_by(self.class.main_store_id).object(key(style)).presigned_url(:get)
       end

--- a/lib/paperclip/storage/no_cache_s3.rb
+++ b/lib/paperclip/storage/no_cache_s3.rb
@@ -101,8 +101,13 @@ module Paperclip
         return unless synced_to?(self.class.main_store_id)
 
         if self.class.download_by_url
-          URI.parse(presigned_url(style)).open do |tempfile|
-            create_tempfile(tempfile.read)
+          begin
+            URI.parse(download_url(style)).open do |tempfile|
+              create_tempfile(tempfile.read)
+            end
+          rescue OpenURI::HTTPError, SocketError, Errno::ECONNREFUSED, Net::OpenTimeout, Net::ReadTimeout => e
+            Paperclip.log("download_by_url failed (#{e.class}: #{e.message}), fallback to API")
+            download_from_store(self.class.main_store_id, style_key)
           end
         else
           download_from_store(self.class.main_store_id, style_key)

--- a/test/storage/no_cache_s3_test.rb
+++ b/test/storage/no_cache_s3_test.rb
@@ -129,7 +129,7 @@ class NoCacheS3Test < Test::Unit::TestCase
     context "with download_by_url" do
       setup do
         @instance.avatar.class.instance_variable_set(:@download_by_url, true)
-        @instance.avatar.stubs(:unpresigned_url).returns("http://example.com/some_file") # чтобы не стабать store.object.presigned_uri
+        @instance.avatar.stubs(:url_without_cdn).returns("http://example.com/some_file") # чтобы не стабать store.object.presigned_uri
         require 'open-uri'
         # правильнее было бы webmock притащить и сам запрос застабить, но ради одного теста жирновато
         Net::HTTP.any_instance.stubs(:start).yields(nil)
@@ -206,7 +206,7 @@ class NoCacheS3Test < Test::Unit::TestCase
     end
   end
 
-  context 'generating unpresigned_url' do
+  context 'generating url_without_cdn' do
     setup do
       object_stub = mock
       object_stub.stubs(:presigned_url).with(:get).returns('https://bucket.example/images/products/1/key.jpg?X-Amz-Signature=abc')
@@ -217,7 +217,7 @@ class NoCacheS3Test < Test::Unit::TestCase
       @instance.avatar = stub_file('pixel.gif', @gif_pixel)
       assert_equal(
         'https://bucket.example/images/products/1/key.jpg?X-Amz-Signature=abc',
-        @instance.avatar.send(:unpresigned_url, :original)
+        @instance.avatar.send(:url_without_cdn, :original)
       )
     end
   end

--- a/test/storage/no_cache_s3_test.rb
+++ b/test/storage/no_cache_s3_test.rb
@@ -5,6 +5,7 @@ require 'sidekiq'
 require 'sidekiq/testing'
 require 'aws-sdk-s3'
 require 'base64'
+require 'socket'
 
 require 'delayed_paperclip'
 DelayedPaperclip::Railtie.insert
@@ -104,6 +105,13 @@ class NoCacheS3Test < Test::Unit::TestCase
     assert_empty(leftover_files)
   end
 
+  def minio_running?
+    TCPSocket.new('127.0.0.1', 9002).close
+    true
+  rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, SocketError
+    false
+  end
+
   context "reprocess" do
     setup do
       Sidekiq::Testing.fake!
@@ -121,7 +129,7 @@ class NoCacheS3Test < Test::Unit::TestCase
     context "with download_by_url" do
       setup do
         @instance.avatar.class.instance_variable_set(:@download_by_url, true)
-        @instance.avatar.stubs(:download_url).returns("http://example.com/some_file") # чтобы не стабать store.object.presigned_uri
+        @instance.avatar.stubs(:unpresigned_url).returns("http://example.com/some_file") # чтобы не стабать store.object.presigned_uri
         require 'open-uri'
         # правильнее было бы webmock притащить и сам запрос застабить, но ради одного теста жирновато
         Net::HTTP.any_instance.stubs(:start).yields(nil)
@@ -168,11 +176,10 @@ class NoCacheS3Test < Test::Unit::TestCase
     end
 
     should "add job and process" do
-      # @store1_stub.expects(:put_object).once
-      # @store2_stub.expects(:put_object).never
+      omit 'minio is not running on localhost:9002' unless minio_running?
+
       assert_no_leftover_tmp do
         @instance.update!(avatar: stub_file('pixel.gif', @gif_pixel))
-        # @instance.update!(avatar: File.open('sample_notebook_1.jpg'))
       end
       assert_equal(1, DelayedPaperclip::Jobs::Sidekiq.jobs.size)
 
@@ -181,7 +188,25 @@ class NoCacheS3Test < Test::Unit::TestCase
     end
   end unless ENV['CI']
 
-  context 'generating download_url' do
+  context 'generating presigned_url' do
+    setup do
+      Dummy::AvatarAttachment.any_instance.stubs(:storage_url).returns('http://домен.pф/ключ?param1=параметр')
+      object_stub = mock
+      object_stub.stubs(:presigned_url).returns('http://другой.домен?param2=param_value')
+      @store1_stub.stubs(:object).returns(object_stub)
+    end
+
+    should 'escape cyrillic and work' do
+      @instance.avatar = stub_file('кириллица.txt', 'qwe')
+      assert_equal(
+        "http://xn--d1acufc.xn--p-eub/%D0%BA%D0%BB%D1%8E%D1%87?"\
+        "param1=%D0%BF%D0%B0%D1%80%D0%B0%D0%BC%D0%B5%D1%82%D1%80&param2=param_value",
+        @instance.avatar.send(:presigned_url, :original)
+      )
+    end
+  end
+
+  context 'generating unpresigned_url' do
     setup do
       object_stub = mock
       object_stub.stubs(:presigned_url).with(:get).returns('https://bucket.example/images/products/1/key.jpg?X-Amz-Signature=abc')
@@ -192,7 +217,7 @@ class NoCacheS3Test < Test::Unit::TestCase
       @instance.avatar = stub_file('pixel.gif', @gif_pixel)
       assert_equal(
         'https://bucket.example/images/products/1/key.jpg?X-Amz-Signature=abc',
-        @instance.avatar.send(:download_url, :original)
+        @instance.avatar.send(:unpresigned_url, :original)
       )
     end
   end

--- a/test/storage/no_cache_s3_test.rb
+++ b/test/storage/no_cache_s3_test.rb
@@ -121,7 +121,7 @@ class NoCacheS3Test < Test::Unit::TestCase
     context "with download_by_url" do
       setup do
         @instance.avatar.class.instance_variable_set(:@download_by_url, true)
-        @instance.avatar.stubs(:presigned_url).returns("http://example.com/some_file") # чтобы не стабать store.object.presigned_uri
+        @instance.avatar.stubs(:download_url).returns("http://example.com/some_file") # чтобы не стабать store.object.presigned_uri
         require 'open-uri'
         # правильнее было бы webmock притащить и сам запрос застабить, но ради одного теста жирновато
         Net::HTTP.any_instance.stubs(:start).yields(nil)

--- a/test/storage/no_cache_s3_test.rb
+++ b/test/storage/no_cache_s3_test.rb
@@ -137,6 +137,19 @@ class NoCacheS3Test < Test::Unit::TestCase
         @store1_stub.expects(:put_object).times(1 + (@instance.avatar.options[:styles].keys - [:original]).size)
         assert_no_leftover_tmp { @instance.avatar.reprocess! }
       end
+
+      should "fallback to API when download_by_url returns HTTP error" do
+        Dummy::AvatarAttachment.any_instance.unstub(:download_from_store)
+        uri_stub = stub
+        uri_stub.expects(:open).raises(OpenURI::HTTPError.new('404 Not Found', StringIO.new))
+        URI.stubs(:parse).with("http://example.com/some_file").returns(uri_stub)
+
+        file = stub_file('pixel.gif', @gif_pixel)
+        @instance.avatar.expects(:download_from_store).with(:store_1, @instance.avatar.key(:original)).returns(file)
+        @store1_stub.expects(:put_object).times(1 + (@instance.avatar.options[:styles].keys - [:original]).size)
+
+        assert_no_leftover_tmp { @instance.avatar.reprocess! }
+      end
     end
   end
 
@@ -168,20 +181,18 @@ class NoCacheS3Test < Test::Unit::TestCase
     end
   end unless ENV['CI']
 
-  context 'generating presigned_url' do
+  context 'generating download_url' do
     setup do
-      Dummy::AvatarAttachment.any_instance.stubs(:storage_url).returns('http://домен.pф/ключ?param1=параметр')
       object_stub = mock
-      object_stub.stubs(:presigned_url).returns('http://другой.домен?param2=param_value')
+      object_stub.stubs(:presigned_url).with(:get).returns('https://bucket.example/images/products/1/key.jpg?X-Amz-Signature=abc')
       @store1_stub.stubs(:object).returns(object_stub)
     end
 
-    should 'escape cyrillic and work' do
-      @instance.avatar = stub_file('кириллица.txt', 'qwe')
+    should 'use main store object presigned url without CDN host' do
+      @instance.avatar = stub_file('pixel.gif', @gif_pixel)
       assert_equal(
-        "http://xn--d1acufc.xn--p-eub/%D0%BA%D0%BB%D1%8E%D1%87?"\
-        "param1=%D0%BF%D0%B0%D1%80%D0%B0%D0%BC%D0%B5%D1%82%D1%80&param2=param_value",
-        @instance.avatar.send(:presigned_url, :original)
+        'https://bucket.example/images/products/1/key.jpg?X-Amz-Signature=abc',
+        @instance.avatar.send(:download_url, :original)
       )
     end
   end


### PR DESCRIPTION
из-за описанной причины не загружаются изображения у юзеров, кто использует кастомный cdn

фикс проверен на проде через консоль, у пользователя все загрузилось
[insales][PRODUCTION] main:0> image.image.process_delayed!
[paperclip] Saving to sbercloud:images/products/1/7609/3224182201/1__1___1_.jpg
[paperclip] Saving to sbercloud:images/products/1/7609/3224182201/large_1__1___1_.jpg
[paperclip] Saving to sbercloud:images/products/1/7609/3224182201/medium_1__1___1_.jpg
[paperclip] Saving to sbercloud:images/products/1/7609/3224182201/compact_1__1___1_.jpg
[paperclip] Saving to sbercloud:images/products/1/7609/3224182201/thumb_1__1___1_.jpg
[paperclip] Saving to sbercloud:images/products/1/7609/3224182201/micro_1__1___1_.jpg
=> false

<img width="2416" height="607" alt="image" src="https://github.com/user-attachments/assets/a3d13322-2871-4ebe-95d3-84639a8c5d32" />
